### PR TITLE
Fix handling access-token

### DIFF
--- a/src/examples/test-run.yml
+++ b/src/examples/test-run.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
 
   orbs:
-    autify-web: autify/autify-web@1
+    autify-web: autify/autify-web@2
 
   workflows:
     test-run:

--- a/src/scripts/test-run.bash
+++ b/src/scripts/test-run.bash
@@ -8,7 +8,9 @@ AUTIFY=${INPUT_AUTIFY_PATH}
 
 ARGS=${INPUT_AUTIFY_TEST_URL}
 
-if [ -z "${INPUT_ACCESS_TOKEN}" ]; then
+ACCESS_TOKEN=${INPUT_ACCESS_TOKEN}
+
+if [ -z "${ACCESS_TOKEN}" ]; then
   echo "Missing access-token."
   exit 1
 fi
@@ -52,4 +54,4 @@ if ! [ -z "${INPUT_OS_VERSION}" ]; then
   add_args "--os-version=${INPUT_OS_VERSION}"
 fi
 
-AUTIFY_WEB_ACCESS_TOKEN=${INPUT_ACCESS_TOKEN} ${AUTIFY} web test run ${ARGS}
+AUTIFY_WEB_ACCESS_TOKEN=${ACCESS_TOKEN} ${AUTIFY} web test run ${ARGS}


### PR DESCRIPTION
`env_var_name` passes the name of environment variable so that we need to expand it in the bash script.

Also, the example used a wrong version and this commit fixes it as well.