### PR TITLE
Add verbose option

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -23,10 +23,12 @@ jobs:
       - autify-web/test-run:
           autify-test-url: https://app.autify.com/projects/743/scenarios/91437
           autify-path: ./node_modules/.bin/autify-with-proxy
+          verbose: false
       - autify-web/test-run:
           autify-test-url: https://app.autify.com/projects/743/scenarios/91437
           autify-path: ./node_modules/.bin/autify-with-proxy
-          wait: 'true'
+          wait: true
+          verbose: false
 workflows:
   test-deploy:
     jobs:

--- a/src/commands/test-run.yml
+++ b/src/commands/test-run.yml
@@ -9,9 +9,12 @@ parameters:
   autify-test-url:
     type: string
     description: 'URL of a test scenario or test plan e.g. https://app.autify.com/projects/<ID>/(scenarios|test_plans)/<ID>'
+  verbose:
+    type: boolean
+    default: true
   wait:
-    type: string
-    default: 'false'
+    type: boolean
+    default: false
     description: 'When true, the action waits until the test finishes.'
   timeout:
     type: string
@@ -55,6 +58,7 @@ steps:
       environment:
         INPUT_ACCESS_TOKEN: << parameters.access-token >>
         INPUT_AUTIFY_TEST_URL: << parameters.autify-test-url >>
+        INPUT_VERBOSE: << parameters.verbose >>
         INPUT_WAIT: << parameters.wait >>
         INPUT_TIMEOUT: << parameters.timeout >>
         INPUT_URL_REPLACEMENTS: << parameters.url-replacements >>

--- a/src/jobs/test-run.yml
+++ b/src/jobs/test-run.yml
@@ -16,9 +16,12 @@ parameters:
   autify-test-url:
     type: string
     description: 'URL of a test scenario or test plan e.g. https://app.autify.com/projects/<ID>/(scenarios|test_plans)/<ID>'
+  verbose:
+    type: boolean
+    default: true
   wait:
-    type: string
-    default: 'false'
+    type: boolean
+    default: false
     description: 'When true, the action waits until the test finishes.'
   timeout:
     type: string
@@ -62,6 +65,7 @@ steps:
   - test-run:
       access-token: << parameters.access-token >>
       autify-test-url: << parameters.autify-test-url >>
+      verbose: << parameters.verbose >>
       wait: << parameters.wait >>
       timeout: << parameters.timeout >>
       url-replacements: << parameters.url-replacements >>

--- a/src/scripts/test-run.bash
+++ b/src/scripts/test-run.bash
@@ -15,7 +15,11 @@ if [ -z "${ACCESS_TOKEN}" ]; then
   exit 1
 fi
 
-if [ "${INPUT_WAIT}" = "true" ]; then 
+if [ "${INPUT_VERBOSE}" = "1" ]; then
+  add_args "--verbose"
+fi
+
+if [ "${INPUT_WAIT}" = "1" ]; then
   add_args "--wait"
 fi
 


### PR DESCRIPTION
Verbose should be enabled for CI execution.

In addition, setting wait option with boolean type as well.