### PR TITLE
Add `autify-connect-key`, unit test and fix a bug of `test-execution-name`

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -16,6 +16,7 @@ jobs:
       - image: 'cimg/node:lts'
     steps:
       - checkout
+      - run: bash test/test.bash
       - autify-cli/install
       - run: npm install @autifyhq/autify-cli-integration-test
       - run: echo 'export AUTIFY_WEB_ACCESS_TOKEN="token"' >> $BASH_ENV

--- a/src/commands/test-run.yml
+++ b/src/commands/test-run.yml
@@ -48,6 +48,10 @@ parameters:
     type: string
     default: ''
     description: 'OS version for running the test scenario (not supported by test plan executions)'
+  autify-connect-key:
+    type: string
+    default: ''
+    description: 'Name of the Autify Connect Key (not supported by test plan executions)'
   autify-path:
     type: string
     default: 'autify'
@@ -62,12 +66,13 @@ steps:
         INPUT_WAIT: << parameters.wait >>
         INPUT_TIMEOUT: << parameters.timeout >>
         INPUT_URL_REPLACEMENTS: << parameters.url-replacements >>
-        TEST_EXECUTION_NAME: << parameters.test-execution-name >>
+        INPUT_TEST_EXECUTION_NAME: << parameters.test-execution-name >>
         INPUT_BROWSER: << parameters.browser >>
         INPUT_DEVICE: << parameters.device >>
         INPUT_DEVICE_TYPE: << parameters.device-type >>
         INPUT_OS: << parameters.os >>
         INPUT_OS_VERSION: << parameters.os-version >>
+        INPUT_AUTIFY_CONNECT_KEY: << parameters.autify-connect-key >>
         INPUT_AUTIFY_PATH: << parameters.autify-path >>
       name: Run a test scenario or test plan
       command: <<include(scripts/test-run.sh)>>

--- a/src/jobs/test-run.yml
+++ b/src/jobs/test-run.yml
@@ -55,6 +55,10 @@ parameters:
     type: string
     default: ''
     description: 'OS version for running the test scenario (not supported by test plan executions)'
+  autify-connect-key:
+    type: string
+    default: ''
+    description: 'Name of the Autify Connect Key (not supported by test plan executions)'
   autify-path:
     type: string
     default: 'autify'
@@ -75,4 +79,5 @@ steps:
       device-type: << parameters.device-type >>
       os: << parameters.os >>
       os-version: << parameters.os-version >>
+      autify-connect-key: << parameters.autify-connect-key >>
       autify-path: << parameters.autify-path >>

--- a/src/scripts/test-run.sh
+++ b/src/scripts/test-run.sh
@@ -41,7 +41,7 @@ if [ -n "${INPUT_URL_REPLACEMENTS}" ]; then
   done
 fi
 
-if [ -n "${INPUT_NAME}" ]; then
+if [ -n "${INPUT_TEST_EXECUTION_NAME}" ]; then
   add_args "--name=${INPUT_TEST_EXECUTION_NAME}"
 fi
 
@@ -63,6 +63,10 @@ fi
 
 if [ -n "${INPUT_OS_VERSION}" ]; then
   add_args "--os-version=${INPUT_OS_VERSION}"
+fi
+
+if [ -n "${INPUT_AUTIFY_CONNECT_KEY}" ]; then
+  add_args "--autify-connect-key=${INPUT_AUTIFY_CONNECT_KEY}"
 fi
 
 AUTIFY_WEB_ACCESS_TOKEN="${ACCESS_TOKEN}" "${AUTIFY}" web test run "${ARGS[@]}"

--- a/test/autify-mock
+++ b/test/autify-mock
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo autify "$@"
+cat "$(dirname "$0")"/log

--- a/test/autify-mock-fail
+++ b/test/autify-mock-fail
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+echo autify-fail "$@"
+cat "$(dirname "$0")"/log
+exit 1

--- a/test/log
+++ b/test/log
@@ -1,0 +1,2 @@
+log %
+Successfully started: https://result

--- a/test/test.bash
+++ b/test/test.bash
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+log_file=$(dirname "$0")/log
+
+
+function before() {
+  export ACCESS_TOKEN=test
+  unset INPUT_AUTIFY_PATH
+  unset INPUT_ACCESS_TOKEN
+  unset INPUT_AUTIFY_TEST_URL
+  export INPUT_VERBOSE=0
+  export INPUT_WAIT=0
+  unset INPUT_TIMEOUT
+  unset INPUT_URL_REPLACEMENTS
+  unset INPUT_TEST_EXECUTION_NAME
+  unset INPUT_BROWSER
+  unset INPUT_DEVICE
+  unset INPUT_DEVICE_TYPE
+  unset INPUT_OS
+  unset INPUT_OS_VERSION
+  unset INPUT_AUTIFY_CONNECT_KEY
+  echo "=== TEST ==="
+}
+
+function test_command() {
+  local expected=$1
+  local result
+  result=$(bash ./src/scripts/test-run.sh | head -1)
+
+  if [ "$result" == "$expected" ]; then
+    echo "Passed command: $expected"
+  else
+    echo "Failed command:"
+    echo "  Expected: $expected"
+    echo "  Result  : $result"
+    exit 1
+  fi
+}
+
+function test_code() {
+  local expected=$1
+  bash ./src/scripts/test-run.sh > /dev/null
+  local result=$?
+
+  if [ "$result" == "$expected" ]; then
+    echo "Passed code: $expected"
+  else
+    echo "Failed code:"
+    echo "  Expected: $expected"
+    echo "  Result  : $result"
+    exit 1
+  fi
+}
+
+function test_log() {
+  local result
+  result=$(mktemp)
+  bash ./src/scripts/test-run.sh | tail -n+2 > "$result"
+
+  if (git diff --no-index --quiet -- "$log_file" "$result"); then
+    echo "Passed log:"
+  else
+    echo "Failed log:"
+    git --no-pager diff --no-index -- "$log_file" "$result"
+    exit 1
+  fi
+}
+
+{
+  before
+  export INPUT_AUTIFY_PATH="./test/autify-mock"
+  export INPUT_ACCESS_TOKEN=ACCESS_TOKEN
+  export INPUT_AUTIFY_TEST_URL=a
+  test_command "autify web test run a"
+  test_code 0
+  test_log
+}
+
+{
+  before
+  export INPUT_AUTIFY_PATH="./test/autify-mock"
+  export INPUT_ACCESS_TOKEN=ACCESS_TOKEN
+  export INPUT_AUTIFY_TEST_URL=a
+  export INPUT_VERBOSE=1
+  export INPUT_WAIT=1
+  export INPUT_TIMEOUT=300
+  export INPUT_URL_REPLACEMENTS=b1,b2
+  export INPUT_TEST_EXECUTION_NAME=c
+  export INPUT_BROWSER=d
+  export INPUT_DEVICE=e
+  export INPUT_DEVICE_TYPE=f
+  export INPUT_OS=g
+  export INPUT_OS_VERSION=h
+  export INPUT_AUTIFY_CONNECT_KEY=i
+  test_command "autify web test run a --verbose --wait -t=300 -r=b1 -r=b2 --name=c --browser=d --device=e --device-type=f --os=g --os-version=h --autify-connect-key=i"
+  test_code 0
+  test_log
+}
+
+{
+  before
+  export INPUT_AUTIFY_PATH="./test/autify-mock-fail"
+  export INPUT_ACCESS_TOKEN=ACCESS_TOKEN
+  export INPUT_AUTIFY_TEST_URL=a
+  test_command "autify-fail web test run a"
+  test_code 1
+  test_log
+}


### PR DESCRIPTION
Autify CLI supports `--autify-connect-key` now. This commit adds its
support to the Orb along with the similar unit test to GitHub Actions.

Also, there is a bug in `test-execution-name` and fixes it.