### PR TITLE
Add job level integration tests

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -17,10 +17,18 @@ executors:
   macos:
     macos:
       xcode: 14.0.0
+  integration-test:
+    docker:
+      - image: cimg/node:current
+    resource_class: small
+    shell: bash
+    environment:
+      AUTIFY_WEB_ACCESS_TOKEN: token
+      AUTIFY_CLI_INTEGRATION_TEST_INSTALL: 1
+      AUTIFY_TEST_WAIT_INTERVAL_SECOND: 0
+      AUTIFY_CONNECT_CLIENT_MODE: fake
 
 jobs:
-  # Create a job to test the commands of your orbs.
-  # You may want to add additional validation steps to ensure the commands are working as expected.
   command-tests:
     parameters:
       os:
@@ -52,6 +60,7 @@ jobs:
           autify-cli-installer-url: "https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/beta/install-cicd.bash"
           wait: true
           verbose: false
+
 workflows:
   test-deploy:
     jobs:
@@ -61,6 +70,25 @@ workflows:
           matrix:
             parameters:
               os: [autify-cli/default, macos, windows]
+      - autify-web/test-run:
+          name: job-test-run
+          filters: *filters
+          executor: integration-test
+          autify-test-url: https://app.autify.com/projects/743/scenarios/91437
+          autify-path: autify-with-proxy
+          # TODO: Remove once autify-cli 0.11.0 is released.
+          autify-cli-installer-url: "https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/beta/install-cicd.bash"
+          verbose: false
+      - autify-web/test-run:
+          name: job-test-run-wait
+          filters: *filters
+          executor: integration-test
+          autify-test-url: https://app.autify.com/projects/743/scenarios/91437
+          autify-path: autify-with-proxy
+          # TODO: Remove once autify-cli 0.11.0 is released.
+          autify-cli-installer-url: "https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/beta/install-cicd.bash"
+          verbose: false
+          wait: true
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
@@ -70,6 +98,8 @@ workflows:
           requires:
             - orb-tools/pack
             - command-tests
+            - job-test-run
+            - job-test-run-wait
           context: orb-publishing
           filters:
             branches:

--- a/src/jobs/test-run.yml
+++ b/src/jobs/test-run.yml
@@ -1,14 +1,9 @@
 description: >
   Run a test scenario or test plan.
 
-docker:
-  - image: << parameters.docker-image-for-job >>
+executor: << parameters.executor >>
 
 parameters:
-  docker-image-for-job:
-    type: string
-    default: 'cimg/base:current'
-    description: The docker image to be used for running this job on CircleCI.
   access-token:
     type: env_var_name
     default: AUTIFY_WEB_ACCESS_TOKEN
@@ -63,6 +58,14 @@ parameters:
     type: string
     default: 'autify'
     description: 'A path to `autify`.'
+  autify-cli-installer-url:
+    type: string
+    default: "https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/stable/install-cicd.bash"
+    description: 'Autify CLI installer URL'
+  executor:
+    type: executor
+    default: autify-cli/default
+    description: 'Executor name for this job.'
 
 steps:
   - test-run:
@@ -80,3 +83,4 @@ steps:
       os-version: << parameters.os-version >>
       autify-connect: << parameters.autify-connect >>
       autify-path: << parameters.autify-path >>
+      autify-cli-installer-url: << parameters.autify-cli-installer-url >>


### PR DESCRIPTION
To add the job level integration tests, we change the parameter from docker image to executor which give more flexibility to the users as well.