### PR TITLE
Support Autify Connect options for test plan execution

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -62,6 +62,21 @@ jobs:
           wait: true
           autify-connect-client: true
           verbose: false
+      - autify-web/test-run:
+          autify-test-url: https://app.autify.com/projects/000/test_plans/0000
+          autify-path: autify-with-proxy
+          verbose: false
+      - autify-web/test-run:
+          autify-test-url: https://app.autify.com/projects/000/test_plans/0000
+          autify-path: autify-with-proxy
+          wait: true
+          verbose: false
+      - autify-web/test-run:
+          autify-test-url: https://app.autify.com/projects/000/test_plans/0000
+          autify-path: autify-with-proxy
+          wait: true
+          autify-connect-client: true
+          verbose: false
 
 workflows:
   test-deploy:
@@ -96,6 +111,30 @@ workflows:
           verbose: false
           wait: true
           autify-connect-client: true
+      - autify-web/test-run:
+          name: job-test-run-test-plan
+          filters: *filters
+          executor: integration-test
+          autify-test-url: https://app.autify.com/projects/000/test_plans/0000
+          autify-path: autify-with-proxy
+          verbose: false
+      - autify-web/test-run:
+          name: job-test-run-test-plan-wait
+          filters: *filters
+          executor: integration-test
+          autify-test-url: https://app.autify.com/projects/000/test_plans/0000
+          autify-path: autify-with-proxy
+          verbose: false
+          wait: true
+      - autify-web/test-run:
+          name: job-test-run-test-plan-autify-connect-client
+          filters: *filters
+          executor: integration-test
+          autify-test-url: https://app.autify.com/projects/000/test_plans/0000
+          autify-path: autify-with-proxy
+          verbose: false
+          wait: true
+          autify-connect-client: true
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
@@ -108,6 +147,9 @@ workflows:
             - job-test-run
             - job-test-run-wait
             - job-test-run-autify-connect-client
+            - job-test-run-test-plan
+            - job-test-run-test-plan-wait
+            - job-test-run-test-plan-autify-connect-client
           context: orb-publishing
           filters:
             branches:

--- a/src/commands/test-run.yml
+++ b/src/commands/test-run.yml
@@ -55,11 +55,11 @@ parameters:
   autify-connect:
     type: string
     default: ''
-    description: 'Name of the Autify Connect Access Point (not supported by test plan executions)'
+    description: 'Name of the Autify Connect Access Point'
   autify-connect-client:
     type: boolean
     default: false
-    description: 'When true, start Autify Connect Client. (not supported by test plan executions)'
+    description: 'When true, start Autify Connect Client'
   autify-path:
     type: string
     default: 'autify'

--- a/src/jobs/test-run.yml
+++ b/src/jobs/test-run.yml
@@ -57,7 +57,7 @@ parameters:
   autify-connect:
     type: string
     default: ''
-    description: 'Name of the Autify Connect Access Point (not supported by test plan executions)'
+    description: 'Name of the Autify Connect Access Point'
   autify-path:
     type: string
     default: 'autify'
@@ -65,7 +65,7 @@ parameters:
   autify-connect-client:
     type: boolean
     default: false
-    description: 'When true, start Autify Connect Client. (not supported by test plan executions)'
+    description: 'When true, start Autify Connect Client'
   autify-cli-installer-url:
     type: string
     default: "https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/stable/install-cicd.bash"


### PR DESCRIPTION
Since Autify CLI 0.12.0 supports Autify Connect options for test plan execution, this commit applies the update to this orb and tests.