### PR TITLE
Add default executor

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,7 +1,6 @@
 version: 2.1
 orbs:
   autify-web: autify/autify-web@dev:<<pipeline.git.revision>>
-  autify-cli: autify/autify-cli@2
   node: circleci/node@5
   orb-tools: circleci/orb-tools@11.1
 
@@ -97,7 +96,7 @@ workflows:
           filters: *filters
           matrix:
             parameters:
-              os: [autify-cli/default, macos, windows]
+              os: [autify-web/default, macos, windows]
           autify-cli-installer-url: https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/stable/install-cicd.bash
       - autify-web/test-run:
           name: job-test-run
@@ -176,7 +175,7 @@ workflows:
           name: stable-<< matrix.os >>
           matrix:
             parameters:
-              os: [autify-cli/default, macos, windows]
+              os: [autify-web/default, macos, windows]
           autify-cli-installer-url: https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/stable/install-cicd.bash
   nightly-beta-test:
     when:
@@ -186,5 +185,5 @@ workflows:
           name: beta-<< matrix.os >>
           matrix:
             parameters:
-              os: [autify-cli/default, macos, windows]
+              os: [autify-web/default, macos, windows]
           autify-cli-installer-url: https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/beta/install-cicd.bash

--- a/src/examples/test-run.yml
+++ b/src/examples/test-run.yml
@@ -7,8 +7,16 @@ usage:
   orbs:
     autify-web: autify/autify-web@3
 
+  jobs:
+    test-run-by-command:
+      executor: autify-web/default
+      steps:
+        - autify-web/test-run:
+            autify-test-url: https://app.autify.com/projects/<ID>/(scenarios|test_plans)/<ID>
+
   workflows:
     test-run:
       jobs:
+        - test-run-by-command
         - autify-web/test-run:
             autify-test-url: https://app.autify.com/projects/<ID>/(scenarios|test_plans)/<ID>

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,0 +1,17 @@
+description: >
+  A base Docker image should work.
+docker:
+  - image: 'cimg/base:<<parameters.tag>>'
+resource_class: <<parameters.size>>
+shell: bash
+parameters:
+  tag:
+    default: current
+    description: >
+      Pick a specific cimg/base image variant:
+      https://hub.docker.com/r/cimg/base/tags
+    type: string
+  size:
+    default: small
+    type: string
+    description: Docker executer's resource_class


### PR DESCRIPTION
It is convenient to provide a default executor for the customers who want to use our commands, not jobs.