### PR TITLE
Make timeout and max-retry-count option integer

### DIFF
--- a/src/commands/test-run.yml
+++ b/src/commands/test-run.yml
@@ -17,16 +17,16 @@ parameters:
     default: false
     description: 'When true, the action waits until the test finishes.'
   timeout:
-    type: string
-    default: ''
+    type: integer
+    default: -1
     description: 'Timeout seconds when waiting.'
   url-replacements:
     type: string
     default: ''
     description: 'URL replacements e.g. http://example.com=http://example.net,http://example.org=http://example.net'
   max-retry-count:
-    type: string
-    default: ''
+    type: integer
+    default: -1
     description: 'Maximum retry count while waiting. The command can take up to `timeout * (max-retry-count + 1)`. Only effective with `wait`'
   test-execution-name:
     type: string

--- a/src/jobs/test-run.yml
+++ b/src/jobs/test-run.yml
@@ -19,16 +19,16 @@ parameters:
     default: false
     description: 'When true, the action waits until the test finishes.'
   timeout:
-    type: string
-    default: ''
+    type: integer
+    default: -1
     description: 'Timeout seconds when waiting.'
   url-replacements:
     type: string
     default: ''
     description: 'URL replacements e.g. http://example.com=http://example.net,http://example.org=http://example.net'
   max-retry-count:
-    type: string
-    default: ''
+    type: integer
+    default: -1
     description: 'Maximum retry count while waiting. The command can take up to `timeout * (max-retry-count + 1)`. Only effective with `wait`'
   test-execution-name:
     type: string

--- a/src/scripts/test-run.sh
+++ b/src/scripts/test-run.sh
@@ -30,7 +30,7 @@ if [ "${INPUT_WAIT}" -eq 1 ]; then
   add_args "--wait"
 fi
 
-if [ -n "${INPUT_TIMEOUT}" ]; then
+if [ "${INPUT_TIMEOUT}" -ne -1 ]; then
   add_args "-t=${INPUT_TIMEOUT}"
 fi
 
@@ -41,7 +41,7 @@ if [ -n "${INPUT_URL_REPLACEMENTS}" ]; then
   done
 fi
 
-if [ -n "${INPUT_MAX_RETRY_COUNT}" ]; then
+if [ "${INPUT_MAX_RETRY_COUNT}" -ne -1 ]; then
   add_args "--max-retry-count=${INPUT_MAX_RETRY_COUNT}"
 fi
 

--- a/test/test.bash
+++ b/test/test.bash
@@ -88,7 +88,7 @@ function test_log() {
   export INPUT_WAIT=1
   export INPUT_TIMEOUT=300
   export INPUT_URL_REPLACEMENTS="https://example.com https://example.net,https://example.net https://example.com?foo=bar"
-  export INPUT_MAX_RETRY_COUNT=c
+  export INPUT_MAX_RETRY_COUNT=1
   export INPUT_TEST_EXECUTION_NAME=d
   export INPUT_BROWSER=e
   export INPUT_DEVICE=f
@@ -98,7 +98,7 @@ function test_log() {
   export INPUT_AUTIFY_CONNECT=j
   export INPUT_AUTIFY_CONNECT_CLIENT=1
   export INPUT_AUTIFY_CONNECT_CLIENT_EXTRA_ARGUMENTS=k
-  test_command "autify web test run a --verbose --wait -t=300 -r=\"https://example.com https://example.net\" -r=\"https://example.net https://example.com?foo=bar\" --max-retry-count=c --name=d --browser=e --device=f --device-type=g --os=h --os-version=i --autify-connect=j --autify-connect-client --autify-connect-client-extra-arguments=k"
+  test_command "autify web test run a --verbose --wait -t=300 -r=\"https://example.com https://example.net\" -r=\"https://example.net https://example.com?foo=bar\" --max-retry-count=1 --name=d --browser=e --device=f --device-type=g --os=h --os-version=i --autify-connect=j --autify-connect-client --autify-connect-client-extra-arguments=k"
   test_code 0
   test_log
 }


### PR DESCRIPTION
Internal ticket: https://app.clickup.com/t/864dwfjtm

It's better to use integer instead of string.

This is breaking change so I'll release v4