### PR TITLE
Surround URL replacements option with quotes

### DIFF
--- a/src/scripts/test-run.sh
+++ b/src/scripts/test-run.sh
@@ -37,7 +37,7 @@ fi
 if [ -n "${INPUT_URL_REPLACEMENTS}" ]; then
   IFS=',' read -ra URL_REPLACEMENTS <<< "${INPUT_URL_REPLACEMENTS}"
   for url_replacement in "${URL_REPLACEMENTS[@]}"; do
-    add_args "-r=${url_replacement}"
+    add_args "-r=\"${url_replacement}\""
   done
 fi
 

--- a/test/test.bash
+++ b/test/test.bash
@@ -87,7 +87,7 @@ function test_log() {
   export INPUT_VERBOSE=1
   export INPUT_WAIT=1
   export INPUT_TIMEOUT=300
-  export INPUT_URL_REPLACEMENTS=b1,b2
+  export INPUT_URL_REPLACEMENTS="https://example.com https://example.net,https://example.net https://example.com?foo=bar"
   export INPUT_MAX_RETRY_COUNT=c
   export INPUT_TEST_EXECUTION_NAME=d
   export INPUT_BROWSER=e
@@ -98,7 +98,7 @@ function test_log() {
   export INPUT_AUTIFY_CONNECT=j
   export INPUT_AUTIFY_CONNECT_CLIENT=1
   export INPUT_AUTIFY_CONNECT_CLIENT_EXTRA_ARGUMENTS=k
-  test_command "autify web test run a --verbose --wait -t=300 -r=b1 -r=b2 --max-retry-count=c --name=d --browser=e --device=f --device-type=g --os=h --os-version=i --autify-connect=j --autify-connect-client --autify-connect-client-extra-arguments=k"
+  test_command "autify web test run a --verbose --wait -t=300 -r=\"https://example.com https://example.net\" -r=\"https://example.net https://example.com?foo=bar\" --max-retry-count=c --name=d --browser=e --device=f --device-type=g --os=h --os-version=i --autify-connect=j --autify-connect-client --autify-connect-client-extra-arguments=k"
   test_code 0
   test_log
 }


### PR DESCRIPTION
Internal ticket: https://app.clickup.com/t/864ea29wc

To support space delimiter (https://github.com/autifyhq/autify-cli/pull/389) this change is needed

I'd like to release this change before https://github.com/autifyhq/autify-circleci-orb-web/pull/30 since this one doesn't have a breaking change.