### PR TITLE
Align default timeout value with Autify CLI

### DIFF
--- a/src/commands/test-run.yml
+++ b/src/commands/test-run.yml
@@ -18,7 +18,7 @@ parameters:
     description: 'When true, the action waits until the test finishes.'
   timeout:
     type: integer
-    default: -1
+    default: 300
     description: 'Timeout seconds when waiting.'
   url-replacements:
     type: string

--- a/src/jobs/test-run.yml
+++ b/src/jobs/test-run.yml
@@ -20,7 +20,7 @@ parameters:
     description: 'When true, the action waits until the test finishes.'
   timeout:
     type: integer
-    default: -1
+    default: 300
     description: 'Timeout seconds when waiting.'
   url-replacements:
     type: string


### PR DESCRIPTION
internal ticket: https://autifyhq.atlassian.net/browse/PLAT-206

Currently, default value for timeout is `-1` and it means using the default value of Autify CLI.

https://github.com/autifyhq/autify-circleci-orb-web/blob/41b8df0f3a182ae02121081c6cb14b548b118bea/src/scripts/test-run.sh#L33C1-L35

Autify CLI's default timeout period is 300 seconds.

https://github.com/autifyhq/autify-cli/blob/a5d23059fcde36f6921ce1eb7c7f9a4961440b55/README.md?plain=1#L324

```
root@72d171b85930:/# autify web test run https://app.autify.com/projects/xxx/scenarios/xxx --wait
✅ Successfully started: https://app.autify.com/projects/xxx/results/xxx(Capability is Linux Chrome 114.0)
🕐 Waiting for the test result: https://app.autify.com/projects/xxx/results/xxx
  ⠏ Waiting... (timeout: 300 s)
    → TestPlan: 🚗 Running, TestCases: 🚗 Running
```

However, `-1` appears to imply rather no timeout.

https://circleci.com/developer/orbs/orb/autify/autify-web

To clearify the behavior I'd like to change default value of timeout from -1 to 300.