### PR TITLE
Skip RC007 as curl access is blocked by Cloudflare

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ workflows:
           filters: *filters
       - orb-tools/review:
           filters: *filters
+          exclude: RC007
       - shellcheck/check:
           filters: *filters
       - orb-tools/publish:


### PR DESCRIPTION
Failure: https://app.circleci.com/pipelines/github/autifyhq/autify-circleci-orb-web/1121/workflows/f45e0874-59ea-4b3f-87df-268aa230df1b/jobs/12180/tests

RC007 is a rule to make sure if Home URL is available.
It's accessible with my browser but not available with curl.

```
(in test file review.bats, line 97)
  `exit 1' failed

Home URL: "https://help.autify.com/docs/circleci-integration" is not reachable.
Check the Home URL for this orb.
```

```
$ curl https://help.autify.com/docs/circleci-integration -I -s | head -n 1
HTTP/2 403 
```