### PR TITLE
Update CircleCI mac runner

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -15,8 +15,7 @@ executors:
       image: windows-server-2022-gui:current
   macos:
     macos:
-      xcode: 14.0.0
-    resource_class: 'macos.m1.medium.gen1'
+      xcode: 16.2.0
   integration-test:
     docker:
       - image: cimg/node:current


### PR DESCRIPTION
Updates the CircleCI runner to not pin a specific mac model, in order to avoid problems from the upcoming deprecation.
